### PR TITLE
Update Keip namespaces to codice.org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to keip
 First off, thanks for taking the time to contribute! 🎉
 
-The following is a set of guidelines for contributing to keip, hosted in the OctoConsulting Organization on GitHub. 
+The following is a set of guidelines for contributing to keip, hosted in the Codice Organization on GitHub. 
 These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a 
 pull request.
 
@@ -9,7 +9,7 @@ pull request.
 
 ### Reporting Bugs
 
-If you find a bug, please report it by opening a [GitHub Issue](https://github.com/OctoConsulting/keip/issues). When you do so, please include:
+If you find a bug, please report it by opening a [GitHub Issue](https://github.com/codice/keip/issues). When you do so, please include:
 - A clear and descriptive title.
 - Steps to reproduce the problem.
 - Expected behavior and actual behavior.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ EOF
 
 ```shell
 cat <<'EOF' | kubectl create -f -
-apiVersion: keip.octo.com/v1alpha1
+apiVersion: keip.codice.org/v1alpha1
 kind: IntegrationRoute
 metadata:
   name: example-route

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # keip (Kubernetes Enterprise Integration Patterns)
 
-[![operator](https://github.com/OctoConsulting/keip/actions/workflows/operator.yml/badge.svg?branch=main)](https://github.com/OctoConsulting/keip/actions/workflows/operator.yml)
-[![webhook](https://github.com/OctoConsulting/keip/actions/workflows/webhook.yml/badge.svg?branch=main)](https://github.com/OctoConsulting/keip/actions/workflows/webhook.yml)
-[![minimal-app](https://github.com/OctoConsulting/keip/actions/workflows/minimal-app.yml/badge.svg?branch=main)](https://github.com/OctoConsulting/keip/actions/workflows/minimal-app.yml)
+[![operator](https://github.com/codice/keip/actions/workflows/operator.yml/badge.svg?branch=main)](https://github.com/codice/keip/actions/workflows/operator.yml)
+[![webhook](https://github.com/codice/keip/actions/workflows/webhook.yml/badge.svg?branch=main)](https://github.com/codice/keip/actions/workflows/webhook.yml)
+[![minimal-app](https://github.com/codice/keip/actions/workflows/minimal-app.yml/badge.svg?branch=main)](https://github.com/codice/keip/actions/workflows/minimal-app.yml)
 
 keip is a Kubernetes operator that simplifies the deployment of Spring Integration routes on Kubernetes clusters. This
 operator makes it easy to manage integration flows, enhancing scalability and resilience through Kubernetes.
@@ -28,7 +28,7 @@ operator makes it easy to manage integration flows, enhancing scalability and re
 
 1. **Clone the repository:**
    ```shell
-   git clone https://github.com/OctoConsulting/keip.git && cd keip
+   git clone https://github.com/codice/keip.git && cd keip
    ```
 
 2. **Deploy the keip operator:**

--- a/keip-container-archetype/README.md
+++ b/keip-container-archetype/README.md
@@ -15,7 +15,7 @@ The process for creating a custom keip container is outlined here:
 ```shell 
 mvn archetype:generate -DinteractiveMode=false \
                        -DarchetypeCatalog=local \
-                       -DarchetypeGroupId=com.octo.keip \
+                       -DarchetypeGroupId=org.codice.keip \
                        -DarchetypeArtifactId=keip-container-archetype \
                        -DarchetypeVersion=0.0.1-SNAPSHOT \
                        -DgroupId=com.acme \

--- a/keip-container-archetype/pom.xml
+++ b/keip-container-archetype/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.octo.keip</groupId>
+  <groupId>org.codice.keip</groupId>
   <artifactId>keip-container-archetype</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>

--- a/minimal-app/pom.xml
+++ b/minimal-app/pom.xml
@@ -10,9 +10,9 @@
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
-    <groupId>com.octo.keip</groupId>
+    <groupId>org.codice.keip</groupId>
     <artifactId>minimal-app</artifactId>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
 
     <properties>
         <docker.registry>ghcr.io/codice</docker.registry>

--- a/minimal-app/pom.xml
+++ b/minimal-app/pom.xml
@@ -15,9 +15,9 @@
     <version>0.2.0</version>
 
     <properties>
-        <docker.registry>ghcr.io/octoconsulting</docker.registry>
+        <docker.registry>ghcr.io/codice</docker.registry>
         <image-name>keip/${project.artifactId}</image-name>
-        <container.source.label>https://github.com/octoconsulting/keip</container.source.label>
+        <container.source.label>https://github.com/codice/keip</container.source.label>
 
         <!-- skip deploying jar -->
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/minimal-app/src/main/java/org/codice/keip/KeipApplication.java
+++ b/minimal-app/src/main/java/org/codice/keip/KeipApplication.java
@@ -1,4 +1,4 @@
-package com.octo.keip;
+package org.codice.keip;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -1,6 +1,6 @@
 VERSION ?= 0.12.1
 GIT_TAG := operator_v$(VERSION)
-KEIP_INTEGRATION_IMAGE ?= ghcr.io/octoconsulting/keip/minimal-app:latest
+KEIP_INTEGRATION_IMAGE ?= ghcr.io/codice/keip/minimal-app:latest
 
 KUBECTL := kubectl
 KUBECTL_DELETE := $(KUBECTL) delete --ignore-not-found

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.12.1
+VERSION ?= 0.13.0
 GIT_TAG := operator_v$(VERSION)
 KEIP_INTEGRATION_IMAGE ?= ghcr.io/codice/keip/minimal-app:latest
 

--- a/operator/controller/addons/certmanager/keip-certmanager-controller.yaml
+++ b/operator/controller/addons/certmanager/keip-certmanager-controller.yaml
@@ -5,7 +5,7 @@ metadata:
   name: keip-certmanager-controller
 spec:
   resources:
-    - apiVersion: keip.octo.com/v1alpha1
+    - apiVersion: keip.codice.org/v1alpha1
       resource: integrationroutes
   attachments:
     - apiVersion: cert-manager.io/v1

--- a/operator/controller/core-controller.yaml
+++ b/operator/controller/core-controller.yaml
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
         - name: webhook
-          image: ghcr.io/octoconsulting/keip/route-webhook:0.14.1
+          image: ghcr.io/codice/keip/route-webhook:0.14.1
           ports:
             - containerPort: 7080
               name: webhook-http

--- a/operator/controller/core-controller.yaml
+++ b/operator/controller/core-controller.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   generateSelector: true
   parentResource:
-    apiVersion: keip.octo.com/v1alpha1
+    apiVersion: keip.codice.org/v1alpha1
     resource: integrationroutes
     revisionHistory:
       fieldPaths:

--- a/operator/controller/core-controller.yaml
+++ b/operator/controller/core-controller.yaml
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
         - name: webhook
-          image: ghcr.io/codice/keip/route-webhook:0.14.1
+          image: ghcr.io/codice/keip/route-webhook:0.15.0
           ports:
             - containerPort: 7080
               name: webhook-http

--- a/operator/crd/crd.yaml
+++ b/operator/crd/crd.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: integrationroutes.keip.octo.com
+  name: integrationroutes.keip.codice.org
 spec:
-  group: keip.octo.com
+  group: keip.codice.org
   names:
     kind: IntegrationRoute
     plural: integrationroutes

--- a/operator/examples/basic/README.md
+++ b/operator/examples/basic/README.md
@@ -18,7 +18,7 @@ kubectl apply -k .
 
 This should result in the creation of the following resources:
 
-- IntegrationRoute `keip.octo.com/v1alpha1/testroute`: The custom resource representing a Spring Integration
+- IntegrationRoute `keip.codice.org/v1alpha1/testroute`: The custom resource representing a Spring Integration
   application.
 - ConfigMap `testroute-xml`: Contains the Spring Integration XML configuration.
 - ConfigMap `testroute-props`: Contains the application's configurable properties.

--- a/operator/examples/basic/testroute.yaml
+++ b/operator/examples/basic/testroute.yaml
@@ -1,4 +1,4 @@
-apiVersion: keip.octo.com/v1alpha1
+apiVersion: keip.codice.org/v1alpha1
 kind: IntegrationRoute
 metadata:
   name: testroute

--- a/operator/examples/certmanager-addon/README.md
+++ b/operator/examples/certmanager-addon/README.md
@@ -40,7 +40,7 @@ kubectl apply -k .
 
 This should result in the creation of the following resources:
 
-- IntegrationRoute `keip.octo.com/v1alpha1/testroute`: The custom resource representing a Spring Integration
+- IntegrationRoute `keip.codice.org/v1alpha1/testroute`: The custom resource representing a Spring Integration
   application.
 - ConfigMap `testroute-xml`: Contains the Spring Integration XML configuration.
 - Secret `pkcs12-password`: Password to the PKCS12 keystore.

--- a/operator/examples/certmanager-addon/testroute.yaml
+++ b/operator/examples/certmanager-addon/testroute.yaml
@@ -1,4 +1,4 @@
-apiVersion: keip.octo.com/v1alpha1
+apiVersion: keip.codice.org/v1alpha1
 kind: IntegrationRoute
 metadata:
   name: testroute

--- a/operator/examples/certmanager-addon/testroute.yaml
+++ b/operator/examples/certmanager-addon/testroute.yaml
@@ -26,7 +26,7 @@ metadata:
   name: testroute
 spec:
   selector:
-    app.kubernetes.io/instance: integrationroute-testroute
+    app.kubernetes.io/name: testroute
   ports:
     - name: https-port
       port: 8443

--- a/operator/webhook/Dockerfile
+++ b/operator/webhook/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11.5-slim
 
-LABEL org.opencontainers.image.source=https://github.com/octoconsulting/keip
+LABEL org.opencontainers.image.source=https://github.com/codice/keip
 
 WORKDIR /code/webhook
 

--- a/operator/webhook/Makefile
+++ b/operator/webhook/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.14.1
+VERSION ?= 0.15.0
 HOST_PORT ?= 7080
 GIT_TAG := webhook_v$(VERSION)
 

--- a/operator/webhook/Makefile
+++ b/operator/webhook/Makefile
@@ -2,7 +2,7 @@ VERSION ?= 0.14.1
 HOST_PORT ?= 7080
 GIT_TAG := webhook_v$(VERSION)
 
-IMG_REGISTRY := ghcr.io/octoconsulting
+IMG_REGISTRY := ghcr.io/codice
 IMG_NAME := keip/route-webhook
 FULL_IMAGE_NAME := $(IMG_REGISTRY)/$(IMG_NAME):$(VERSION)
 CONTAINER_NAME := integration-route-webhook

--- a/operator/webhook/addons/certmanager/test/json/full-iroute-request.json
+++ b/operator/webhook/addons/certmanager/test/json/full-iroute-request.json
@@ -1,6 +1,6 @@
 {
   "object": {
-    "apiVersion": "keip.octo.com/v1alpha1",
+    "apiVersion": "keip.codice.org/v1alpha1",
     "kind": "IntegrationRoute",
     "metadata": {
       "annotations": {
@@ -10,62 +10,26 @@
         "cert-manager.io/subject-countries": "US",
         "cert-manager.io/subject-localities": "A Park",
         "cert-manager.io/subject-organizationalunits": "Parks and Recreation",
-        "cert-manager.io/subject-provinces": "FL",
-        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"keip.octo.com/v1alpha1\",\"kind\":\"IntegrationRoute\",\"metadata\":{\"annotations\":{\"cert-manager.io/alt-names\":\"cloud-integration-route-actuator.testnamespace.svc.cluster.local\",\"cert-manager.io/cluster-issuer\":\"test-selfsigned\",\"cert-manager.io/common-name\":\"testroute\",\"cert-manager.io/subject-countries\":\"US\",\"cert-manager.io/subject-localities\":\"A Park\",\"cert-manager.io/subject-organizationalunits\":\"Parks and Recreation\",\"cert-manager.io/subject-provinces\":\"FL\"},\"name\":\"testroute\",\"namespace\":\"testnamespace\"},\"spec\":{\"propSources\":[{\"name\":\"testroute-props\"}],\"routeConfigMap\":\"testroute-xml\",\"secretSources\":[\"testroute-secret\"],\"tls\":{\"keystore\":{\"key\":\"keystore.jks\",\"passwordSecretRef\":\"jks-password\",\"secretName\":\"testroute-certstore\",\"type\":\"jks\"}}}}\n"
+        "cert-manager.io/subject-provinces": "FL"
       },
       "creationTimestamp": "2025-03-18T15:55:04Z",
       "generation": 1,
-      "managedFields": [
-        {
-          "apiVersion": "keip.octo.com/v1alpha1",
-          "fieldsType": "FieldsV1",
-          "fieldsV1": {
-            "f:metadata": {
-              "f:annotations": {
-                ".": {},
-                "f:cert-manager.io/alt-names": {},
-                "f:cert-manager.io/cluster-issuer": {},
-                "f:cert-manager.io/common-name": {},
-                "f:cert-manager.io/subject-countries": {},
-                "f:cert-manager.io/subject-localities": {},
-                "f:cert-manager.io/subject-organizationalunits": {},
-                "f:cert-manager.io/subject-provinces": {},
-                "f:kubectl.kubernetes.io/last-applied-configuration": {}
-              }
-            },
-            "f:spec": {
-              ".": {},
-              "f:propSources": {},
-              "f:replicas": {},
-              "f:routeConfigMap": {},
-              "f:secretSources": {},
-              "f:tls": {
-                ".": {},
-                "f:keystore": {
-                  ".": {},
-                  "f:key": {},
-                  "f:passwordSecretRef": {},
-                  "f:secretName": {},
-                  "f:type": {}
-                }
-              }
-            }
-          },
-          "manager": "kubectl-client-side-apply",
-          "operation": "Update",
-          "time": "2025-03-18T15:55:04Z"
-        }
-      ],
       "name": "testroute",
       "namespace": "testnamespace",
       "resourceVersion": "48692499",
       "uid": "c4d501ce-0196-42f1-bd8c-8dd82759d890"
     },
     "spec": {
-      "propSources": [{ "name": "testroute-props" }],
+      "propSources": [
+        {
+          "name": "testroute-props"
+        }
+      ],
       "replicas": 1,
       "routeConfigMap": "testroute-xml",
-      "secretSources": ["testroute-secret"],
+      "secretSources": [
+        "testroute-secret"
+      ],
       "tls": {
         "keystore": {
           "jks": {
@@ -77,7 +41,9 @@
       }
     }
   },
-  "attachments": { "Certificate.cert-manager.io/v1": {} },
+  "attachments": {
+    "Certificate.cert-manager.io/v1": {}
+  },
   "related": {},
   "finalizing": false
 }

--- a/operator/webhook/core/test/json/full-iroute-request.json
+++ b/operator/webhook/core/test/json/full-iroute-request.json
@@ -1,11 +1,8 @@
 {
   "parent": {
-    "apiVersion": "keip.octo.com/v1alpha1",
+    "apiVersion": "keip.codice.org/v1alpha1",
     "kind": "IntegrationRoute",
     "metadata": {
-      "annotations": {
-        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"keip.octo.com/v1alpha1\",\"kind\":\"IntegrationRoute\",\"metadata\":{\"annotations\":{},\"name\":\"testroute\",\"namespace\":\"demo\"},\"spec\":{\"annotations\":{\"aKey1\":\"aValue1\"},\"labels\":{\"firstKey\":\"firstValue\"},\"persistentVolumeClaims\":[{\"claimName\":\"testroute-pvc\",\"mountPath\":\"/tmp/testdir\"}],\"propSources\":[{\"name\":\"testroute-props\"},{\"labels\":{\"group\":\"ir-common\"}}],\"replicas\":2,\"routeConfigMap\":\"testroute-xml\",\"secretSources\":[\"testroute-secret\"]}}\n"
-      },
       "creationTimestamp": "2023-09-06T01:16:27Z",
       "generation": 1,
       "name": "testroute",
@@ -114,7 +111,7 @@
           "type": "Ready"
         },
         {
-          "message": "latest ControllerRevision: integrationroutes.keip.octo.com-f09ae6b579e26c5b591f2305d1daf1024e293fa7",
+          "message": "latest ControllerRevision: integrationroutes.keip.codice.org-f09ae6b579e26c5b591f2305d1daf1024e293fa7",
           "reason": "OnLatestRevision",
           "status": "True",
           "type": "Updated"

--- a/operator/webhook/test/json/full-cert-request.json
+++ b/operator/webhook/test/json/full-cert-request.json
@@ -7,45 +7,12 @@
       "uid": "79dfff16-d192-439f-8af2-aaa75409514e",
       "resourceVersion": "48689094",
       "generation": 1,
-      "creationTimestamp": "2025-03-18T15:19:49Z",
-      "annotations": {
-        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"metacontroller.k8s.io/v1alpha1\",\"kind\":\"DecoratorController\",\"metadata\":{\"annotations\":{},\"name\":\"keip-certmanager-controller\"},\"spec\":{\"attachments\":[{\"apiVersion\":\"cert-manager.io/v1\",\"resource\":\"certificates\",\"updateStrategy\":{\"method\":\"RollingRecreate\"}}],\"hooks\":{\"sync\":{\"webhook\":{\"url\":\"http://integrationroute-webhook.keip/addons/certmanager/sync\"}}},\"resources\":[{\"apiVersion\":\"keip.octo.com/v1alpha1\",\"resource\":\"integrationroutes\"}]}}\n"
-      },
-      "managedFields": [
-        {
-          "manager": "kubectl-client-side-apply",
-          "operation": "Update",
-          "apiVersion": "metacontroller.k8s.io/v1alpha1",
-          "time": "2025-03-18T15:19:49Z",
-          "fieldsType": "FieldsV1",
-          "fieldsV1": {
-            "f:metadata": {
-              "f:annotations": {
-                ".": {},
-                "f:kubectl.kubernetes.io/last-applied-configuration": {}
-              }
-            },
-            "f:spec": {
-              ".": {},
-              "f:attachments": {},
-              "f:hooks": {
-                ".": {},
-                "f:sync": {
-                  ".": {},
-                  "f:version": {},
-                  "f:webhook": { ".": {}, "f:url": {} }
-                }
-              },
-              "f:resources": {}
-            }
-          }
-        }
-      ]
+      "creationTimestamp": "2025-03-18T15:19:49Z"
     },
     "spec": {
       "resources": [
         {
-          "apiVersion": "keip.octo.com/v1alpha1",
+          "apiVersion": "keip.codice.org/v1alpha1",
           "resource": "integrationroutes"
         }
       ],
@@ -53,7 +20,9 @@
         {
           "apiVersion": "cert-manager.io/v1",
           "resource": "certificates",
-          "updateStrategy": { "method": "RollingRecreate" }
+          "updateStrategy": {
+            "method": "RollingRecreate"
+          }
         }
       ],
       "hooks": {
@@ -68,7 +37,7 @@
     "status": {}
   },
   "object": {
-    "apiVersion": "keip.octo.com/v1alpha1",
+    "apiVersion": "keip.codice.org/v1alpha1",
     "kind": "IntegrationRoute",
     "metadata": {
       "annotations": {
@@ -78,62 +47,26 @@
         "cert-manager.io/subject-countries": "US",
         "cert-manager.io/subject-localities": "A Park",
         "cert-manager.io/subject-organizationalunits": "Parks and Recreation",
-        "cert-manager.io/subject-provinces": "FL",
-        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"keip.octo.com/v1alpha1\",\"kind\":\"IntegrationRoute\",\"metadata\":{\"annotations\":{\"cert-manager.io/alt-names\":\"cloud-integration-route-actuator.default.svc.cluster.local\",\"cert-manager.io/cluster-issuer\":\"test-selfsigned\",\"cert-manager.io/common-name\":\"testroute\",\"cert-manager.io/subject-countries\":\"US\",\"cert-manager.io/subject-localities\":\"A Park\",\"cert-manager.io/subject-organizationalunits\":\"Parks and Recreation\",\"cert-manager.io/subject-provinces\":\"FL\"},\"name\":\"testroute\",\"namespace\":\"default\"},\"spec\":{\"propSources\":[{\"name\":\"testroute-props\"}],\"routeConfigMap\":\"testroute-xml\",\"secretSources\":[\"testroute-secret\"],\"tls\":{\"keystore\":{\"key\":\"keystore.jks\",\"passwordSecretRef\":\"jks-password\",\"secretName\":\"testroute-certstore\",\"type\":\"jks\"}}}}\n"
+        "cert-manager.io/subject-provinces": "FL"
       },
       "creationTimestamp": "2025-03-18T15:55:04Z",
       "generation": 1,
-      "managedFields": [
-        {
-          "apiVersion": "keip.octo.com/v1alpha1",
-          "fieldsType": "FieldsV1",
-          "fieldsV1": {
-            "f:metadata": {
-              "f:annotations": {
-                ".": {},
-                "f:cert-manager.io/alt-names": {},
-                "f:cert-manager.io/cluster-issuer": {},
-                "f:cert-manager.io/common-name": {},
-                "f:cert-manager.io/subject-countries": {},
-                "f:cert-manager.io/subject-localities": {},
-                "f:cert-manager.io/subject-organizationalunits": {},
-                "f:cert-manager.io/subject-provinces": {},
-                "f:kubectl.kubernetes.io/last-applied-configuration": {}
-              }
-            },
-            "f:spec": {
-              ".": {},
-              "f:propSources": {},
-              "f:replicas": {},
-              "f:routeConfigMap": {},
-              "f:secretSources": {},
-              "f:tls": {
-                ".": {},
-                "f:keystore": {
-                  ".": {},
-                  "f:key": {},
-                  "f:passwordSecretRef": {},
-                  "f:secretName": {},
-                  "f:type": {}
-                }
-              }
-            }
-          },
-          "manager": "kubectl-client-side-apply",
-          "operation": "Update",
-          "time": "2025-03-18T15:55:04Z"
-        }
-      ],
       "name": "testroute",
       "namespace": "testnamespace",
       "resourceVersion": "48692499",
       "uid": "c4d501ce-0196-42f1-bd8c-8dd82759d890"
     },
     "spec": {
-      "propSources": [{ "name": "testroute-props" }],
+      "propSources": [
+        {
+          "name": "testroute-props"
+        }
+      ],
       "replicas": 1,
       "routeConfigMap": "testroute-xml",
-      "secretSources": ["testroute-secret"],
+      "secretSources": [
+        "testroute-secret"
+      ],
       "tls": {
         "keystore": {
           "jks": {
@@ -145,7 +78,9 @@
       }
     }
   },
-  "attachments": { "Certificate.cert-manager.io/v1": {} },
+  "attachments": {
+    "Certificate.cert-manager.io/v1": {}
+  },
   "related": {},
   "finalizing": false
 }

--- a/operator/webhook/test/json/full-route-request.json
+++ b/operator/webhook/test/json/full-route-request.json
@@ -7,52 +7,17 @@
       "uid": "1dfca480-3ea5-4778-8538-54c35c11f31b",
       "resourceVersion": "48692412",
       "generation": 1,
-      "creationTimestamp": "2025-03-18T15:54:33Z",
-      "annotations": {
-        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"metacontroller.k8s.io/v1alpha1\",\"kind\":\"CompositeController\",\"metadata\":{\"annotations\":{},\"name\":\"keip-integrationroute-controller\"},\"spec\":{\"childResources\":[{\"apiVersion\":\"apps/v1\",\"resource\":\"deployments\",\"updateStrategy\":{\"method\":\"RollingRecreate\",\"statusChecks\":{\"conditions\":[{\"status\":\"True\",\"type\":\"Ready\"}]}}},{\"apiVersion\":\"v1\",\"resource\":\"services\",\"updateStrategy\":{\"method\":\"RollingRecreate\",\"statusChecks\":{\"conditions\":[{\"status\":\"True\",\"type\":\"Ready\"}]}}}],\"generateSelector\":true,\"hooks\":{\"sync\":{\"webhook\":{\"timeout\":\"10s\",\"url\":\"http://integrationroute-webhook.keip/sync\"}}},\"parentResource\":{\"apiVersion\":\"keip.octo.com/v1alpha1\",\"resource\":\"integrationroutes\",\"revisionHistory\":{\"fieldPaths\":[\"spec.routeConfigMap\"]}}}}\n"
-      },
-      "managedFields": [
-        {
-          "manager": "kubectl-client-side-apply",
-          "operation": "Update",
-          "apiVersion": "metacontroller.k8s.io/v1alpha1",
-          "time": "2025-03-18T15:54:33Z",
-          "fieldsType": "FieldsV1",
-          "fieldsV1": {
-            "f:metadata": {
-              "f:annotations": {
-                ".": {},
-                "f:kubectl.kubernetes.io/last-applied-configuration": {}
-              }
-            },
-            "f:spec": {
-              ".": {},
-              "f:childResources": {},
-              "f:generateSelector": {},
-              "f:hooks": {
-                ".": {},
-                "f:sync": {
-                  ".": {},
-                  "f:version": {},
-                  "f:webhook": { ".": {}, "f:timeout": {}, "f:url": {} }
-                }
-              },
-              "f:parentResource": {
-                ".": {},
-                "f:apiVersion": {},
-                "f:resource": {},
-                "f:revisionHistory": { ".": {}, "f:fieldPaths": {} }
-              }
-            }
-          }
-        }
-      ]
+      "creationTimestamp": "2025-03-18T15:54:33Z"
     },
     "spec": {
       "parentResource": {
-        "apiVersion": "keip.octo.com/v1alpha1",
+        "apiVersion": "keip.codice.org/v1alpha1",
         "resource": "integrationroutes",
-        "revisionHistory": { "fieldPaths": ["spec.routeConfigMap"] }
+        "revisionHistory": {
+          "fieldPaths": [
+            "spec.routeConfigMap"
+          ]
+        }
       },
       "childResources": [
         {
@@ -61,7 +26,12 @@
           "updateStrategy": {
             "method": "RollingRecreate",
             "statusChecks": {
-              "conditions": [{ "type": "Ready", "status": "True" }]
+              "conditions": [
+                {
+                  "type": "Ready",
+                  "status": "True"
+                }
+              ]
             }
           }
         },
@@ -71,7 +41,12 @@
           "updateStrategy": {
             "method": "RollingRecreate",
             "statusChecks": {
-              "conditions": [{ "type": "Ready", "status": "True" }]
+              "conditions": [
+                {
+                  "type": "Ready",
+                  "status": "True"
+                }
+              ]
             }
           }
         }
@@ -90,7 +65,7 @@
     "status": {}
   },
   "parent": {
-    "apiVersion": "keip.octo.com/v1alpha1",
+    "apiVersion": "keip.codice.org/v1alpha1",
     "kind": "IntegrationRoute",
     "metadata": {
       "annotations": {
@@ -100,62 +75,26 @@
         "cert-manager.io/subject-countries": "US",
         "cert-manager.io/subject-localities": "A Park",
         "cert-manager.io/subject-organizationalunits": "Parks and Recreation",
-        "cert-manager.io/subject-provinces": "FL",
-        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"keip.octo.com/v1alpha1\",\"kind\":\"IntegrationRoute\",\"metadata\":{\"annotations\":{\"cert-manager.io/alt-names\":\"cloud-integration-route-actuator.default.svc.cluster.local\",\"cert-manager.io/cluster-issuer\":\"test-selfsigned\",\"cert-manager.io/common-name\":\"testroute\",\"cert-manager.io/subject-countries\":\"US\",\"cert-manager.io/subject-localities\":\"A Park\",\"cert-manager.io/subject-organizationalunits\":\"Parks and Recreation\",\"cert-manager.io/subject-provinces\":\"FL\"},\"name\":\"testroute\",\"namespace\":\"default\"},\"spec\":{\"propSources\":[{\"name\":\"testroute-props\"}],\"routeConfigMap\":\"testroute-xml\",\"secretSources\":[\"testroute-secret\"],\"tls\":{\"keystore\":{\"key\":\"keystore.jks\",\"passwordSecretRef\":\"jks-password\",\"secretName\":\"testroute-certstore\",\"type\":\"jks\"}}}}\n"
+        "cert-manager.io/subject-provinces": "FL"
       },
       "creationTimestamp": "2025-03-18T15:55:04Z",
       "generation": 1,
-      "managedFields": [
-        {
-          "apiVersion": "keip.octo.com/v1alpha1",
-          "fieldsType": "FieldsV1",
-          "fieldsV1": {
-            "f:metadata": {
-              "f:annotations": {
-                ".": {},
-                "f:cert-manager.io/alt-names": {},
-                "f:cert-manager.io/cluster-issuer": {},
-                "f:cert-manager.io/common-name": {},
-                "f:cert-manager.io/subject-countries": {},
-                "f:cert-manager.io/subject-localities": {},
-                "f:cert-manager.io/subject-organizationalunits": {},
-                "f:cert-manager.io/subject-provinces": {},
-                "f:kubectl.kubernetes.io/last-applied-configuration": {}
-              }
-            },
-            "f:spec": {
-              ".": {},
-              "f:propSources": {},
-              "f:replicas": {},
-              "f:routeConfigMap": {},
-              "f:secretSources": {},
-              "f:tls": {
-                ".": {},
-                "f:keystore": {
-                  ".": {},
-                  "f:key": {},
-                  "f:passwordSecretRef": {},
-                  "f:secretName": {},
-                  "f:type": {}
-                }
-              }
-            }
-          },
-          "manager": "kubectl-client-side-apply",
-          "operation": "Update",
-          "time": "2025-03-18T15:55:04Z"
-        }
-      ],
       "name": "testroute",
       "namespace": "testnamespace",
       "resourceVersion": "48692499",
       "uid": "c4d501ce-0196-42f1-bd8c-8dd82759d890"
     },
     "spec": {
-      "propSources": [{ "name": "testroute-props" }],
+      "propSources": [
+        {
+          "name": "testroute-props"
+        }
+      ],
       "replicas": 1,
       "routeConfigMap": "testroute-xml",
-      "secretSources": ["testroute-secret"],
+      "secretSources": [
+        "testroute-secret"
+      ],
       "tls": {
         "keystore": {
           "jks": {
@@ -167,7 +106,10 @@
       }
     }
   },
-  "children": { "Deployment.apps/v1": {}, "Service.v1": {} },
+  "children": {
+    "Deployment.apps/v1": {},
+    "Service.v1": {}
+  },
   "related": {},
   "finalizing": false
 }


### PR DESCRIPTION
As the Keip repository is now part of the Codice org, update all `octo/OctoConsulting` references to `codice`.