### PR TITLE
Add Deployment Route and Kubernetes Client for Integration Routes

### DIFF
--- a/operator/controller/core-controller.yaml
+++ b/operator/controller/core-controller.yaml
@@ -46,6 +46,7 @@ metadata:
   namespace: keip
 spec:
   replicas: 1
+  service-account: integrationroute-service
   selector:
     matchLabels:
       app: integrationroute-webhook

--- a/operator/controller/core-controller.yaml
+++ b/operator/controller/core-controller.yaml
@@ -46,7 +46,6 @@ metadata:
   namespace: keip
 spec:
   replicas: 1
-  service-account: integrationroute-service
   selector:
     matchLabels:
       app: integrationroute-webhook
@@ -55,6 +54,7 @@ spec:
       labels:
         app: integrationroute-webhook
     spec:
+      serviceAccountName: controller-service
       containers:
         - name: webhook
           image: ghcr.io/codice/keip/webapp:0.16.0

--- a/operator/controller/core-privileges.yaml
+++ b/operator/controller/core-privileges.yaml
@@ -24,3 +24,38 @@ roleRef:
   kind: Role
   name: spring-cloud-kubernetes
   apiGroup: ""
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-service
+  namespace: keip
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: controller-kubernetes-manager
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["keip.codice.org"]
+    resources: ["integrationroutes"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: controller-kubernetes-binding
+subjects:
+  - kind: ServiceAccount
+    name: controller-service
+    namespace: keip
+    apiGroup: ""
+roleRef:
+  kind: ClusterRole
+  name: controller-kubernetes-manager
+  apiGroup: ""

--- a/operator/webapp/README.md
+++ b/operator/webapp/README.md
@@ -2,13 +2,9 @@
 
 A Python web server that implements the following endpoints:
 - `/webhook`: A [lambda controller from the Metacontroller API](https://metacontroller.github.io/metacontroller/concepts.html#lambda-controller).
-- `/deploy`: Deploys a route from an XML file.
-- `/cluster-health`: Returns the health of the cluster.
-The webhook will be called as part of the Metacontroller control loop when `IntegrationRoute` parent
-resources are detected.
+- `/route`: Deploys a route from an XML file.
 
-  The webhook contains two endpoints, `/webhook/sync` and `/webhook/addons/certmanager/sync`.
-
+The webhook contains two endpoints, `/webhook/sync` and `/webhook/addons/certmanager/sync`.
   - `/webhook/sync`: The core logic that creates a `Deployment` from `IntegrationRoute` resources.
   - `/webhook/addons/certmanager/sync`: An add-on that creates
     a [cert-manager.io/v1.Certificate](https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.Certificate)
@@ -21,7 +17,7 @@ resources are detected.
 
 This web server is designed to be run as a service within a Kubernetes cluster. It is intended to be used with [Metacontroller](https://metacontroller.github.io/metacontroller/), which will call the `/webhook` endpoint to manage `IntegrationRoute` custom resources.
 
-The `/deploy` endpoint is provided for convenience to deploy routes from XML files. The `/cluster-health` endpoint can be used as a liveness or readiness probe.
+The `/route` endpoint is provided for convenience to deploy routes from XML files. The `/cluster-health` endpoint can be used as a liveness or readiness probe.
 
 ## Developer Guide
 

--- a/operator/webapp/README.md
+++ b/operator/webapp/README.md
@@ -2,6 +2,8 @@
 
 A Python web server that implements the following endpoints:
 - `/webhook`: A [lambda controller from the Metacontroller API](https://metacontroller.github.io/metacontroller/concepts.html#lambda-controller).
+- `/deploy`: Deploys a route from an XML file.
+- `/cluster-health`: Returns the health of the cluster.
 The webhook will be called as part of the Metacontroller control loop when `IntegrationRoute` parent
 resources are detected.
 
@@ -14,6 +16,12 @@ resources are detected.
 
   The format for the request and response JSON payloads can be
   seen [here](https://metacontroller.github.io/metacontroller/api/compositecontroller.html#sync-hook)
+
+## Deployment
+
+This web server is designed to be run as a service within a Kubernetes cluster. It is intended to be used with [Metacontroller](https://metacontroller.github.io/metacontroller/), which will call the `/webhook` endpoint to manage `IntegrationRoute` custom resources.
+
+The `/deploy` endpoint is provided for convenience to deploy routes from XML files. The `/cluster-health` endpoint can be used as a liveness or readiness probe.
 
 ## Developer Guide
 
@@ -62,6 +70,20 @@ a [pre-commit git hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
 
 ```shell
 make precommit
+```
+
+### Docker
+
+To build the Docker image, run:
+
+```shell
+make build
+```
+
+To run the Docker container:
+
+```shell
+make run-container
 ```
 
 ### Windows Development

--- a/operator/webapp/app.py
+++ b/operator/webapp/app.py
@@ -4,7 +4,7 @@ from starlette.applications import Starlette
 from starlette.types import ASGIApp
 
 import config as cfg
-from routes import webhook
+from routes import webhook, deploy
 from logconf import LOG_CONF
 
 
@@ -19,6 +19,7 @@ def create_app() -> ASGIApp:
 
     app = Starlette(debug=cfg.DEBUG)
     app.mount("/webhook", webhook.router)
+    app.mount("/deploy", deploy.router)
 
     return app
 

--- a/operator/webapp/app.py
+++ b/operator/webapp/app.py
@@ -19,7 +19,7 @@ def create_app() -> ASGIApp:
 
     app = Starlette(debug=cfg.DEBUG)
     app.mount("/webhook", webhook.router)
-    app.mount("/deploy", deploy.router)
+    app.mount("/route", deploy.router)
 
     return app
 

--- a/operator/webapp/core/k8s_client.py
+++ b/operator/webapp/core/k8s_client.py
@@ -1,0 +1,177 @@
+from typing import List
+from kubernetes import config, client
+from kubernetes.client.rest import ApiException
+from urllib3.util.retry import Retry
+import logging.config
+
+from models import RouteData, Resource, Status
+from logconf import LOG_CONF
+
+ROUTE_API_GROUP = "keip.codice.org"
+ROUTE_API_VERSION = "v1alpha1"
+ROUTE_PLURAL = "integrationroutes"
+WEBHOOK_CONTROLLER_PREFIX = "integrationroute-webhook"
+
+
+logging.config.dictConfig(LOG_CONF)
+logging.getLogger("urllib3").setLevel(logging.ERROR)
+_LOGGER = logging.getLogger(__name__)
+
+
+try:
+    # Try in-cluster config first
+    config.load_incluster_config()
+    _LOGGER.info("Using in-cluster Kubernetes config")
+except config.ConfigException:
+    # Fall back to local kubeconfig
+    _LOGGER.info(
+        msg="Detected not running inside a cluster. Falling back to local kubeconfig."
+    )
+    config.load_kube_config()
+
+
+v1 = client.CoreV1Api()
+routeApi = client.CustomObjectsApi()
+
+
+def _check_cluster_reachable():
+    try:
+        v1.list_namespace(limit=1, timeout_seconds=5)
+        return True
+    except Exception:
+        return False
+
+
+def create_integration_route(route_data: RouteData, configmap_name: str) -> Resource:
+    """Create or update a new Integration Route with the provided configmap"""
+    if not _check_cluster_reachable():
+        raise ApiException(
+            status=500,
+            reason="Kubernetes cluster not reachable. Verify the cluster is running"
+        )
+
+    existing_route = routeApi.list_namespaced_custom_object(
+        group=ROUTE_API_GROUP,
+        version=ROUTE_API_VERSION,
+        namespace=route_data.namespace,
+        plural=ROUTE_PLURAL,
+        field_selector=f"metadata.name={route_data.route_name}",
+    )
+
+    body = {
+        "apiVersion": "keip.codice.org/v1alpha1",
+        "kind": "IntegrationRoute",
+        "metadata": {"name": route_data.route_name},
+        "spec": {"routeConfigMap": configmap_name},
+    }
+
+    status = Status.CREATED
+
+    if existing_route["items"]:
+        # Recreate route
+        routeApi.delete_namespaced_custom_object(
+            group=ROUTE_API_GROUP,
+            version=ROUTE_API_VERSION,
+            namespace=route_data.namespace,
+            plural=ROUTE_PLURAL,
+            name=existing_route["items"][0]["metadata"]["name"],
+        )
+        status = Status.RECREATED
+
+    # Create new route
+    routeApi.create_namespaced_custom_object(
+        group=ROUTE_API_GROUP,
+        version=ROUTE_API_VERSION,
+        namespace=route_data.namespace,
+        plural=ROUTE_PLURAL,
+        body=body,
+    )
+
+    return Resource(status=status, name=route_data.route_name)
+
+
+def create_route_configmap(route_data: RouteData) -> Resource:
+    """Create or update a ConfigMap with an XML route payload"""
+    if not _check_cluster_reachable():
+        raise ApiException(
+            status=500,
+            reason="Kubernetes cluster not reachable. Verify the cluster is running",
+        )
+
+    configmap_name = f"{route_data.route_name}-cm"
+    configmap = client.V1ConfigMap(
+        metadata=client.V1ObjectMeta(
+            name=configmap_name, namespace=route_data.namespace
+        ),
+        data={"integrationRoute.xml": route_data.route_file},
+    )
+
+    result = v1.list_namespaced_config_map(
+        namespace=route_data.namespace, field_selector=f"metadata.name={configmap_name}"
+    )
+
+    updated = False
+
+    if len(result.items) > 0:
+        # Update if exists
+        _LOGGER.info(
+            "Route ConfigMap '%s' already exists and will be updated", configmap_name
+        )
+
+        v1.replace_namespaced_config_map(
+            name=configmap_name, namespace=route_data.namespace, body=configmap
+        )
+        updated = True
+    else:
+        # Create if doesn't exist
+        _LOGGER.info(
+            "Route ConfigMap '%s' does not exist and will be created", configmap_name
+        )
+        configmap = v1.create_namespaced_config_map(
+            namespace=route_data.namespace, body=configmap
+        )
+
+    status = Status.UPDATED if updated else Status.CREATED
+    return Resource(status=status, name=configmap_name)
+
+
+def create_route_resources(route_data: RouteData) -> List[Resource]:
+    route_cm = create_route_configmap(route_data=route_data)
+    route = create_integration_route(
+        route_data=route_data, configmap_name=route_cm.name
+    )
+    return [route_cm, route]
+
+
+def is_cluster_ready() -> bool:
+    if not _check_cluster_reachable():
+        _LOGGER.warning("Kubernetes client not reachable, cluster is not ready")
+        return False
+    try:
+        pods = v1.list_pod_for_all_namespaces()
+        matching_pods = []
+        for pod in pods.items:
+            if pod.metadata.name.startswith(WEBHOOK_CONTROLLER_PREFIX):
+                ready = False
+                if pod.status and pod.status.conditions:
+                    for condition in pod.status.conditions:
+                        if condition.type == "Ready":
+                            ready = condition.status
+                            break
+
+                matching_pods.append(
+                    {
+                        "name": pod.metadata.name,
+                        "ready": ready,
+                        "phase": pod.status.phase if pod.status else "Unknown",
+                    }
+                )
+
+        if any(pod["ready"] for pod in matching_pods):
+            _LOGGER.debug(
+                msg=f"Integration Route Webhook pods ready to take requests: {matching_pods}"
+            )
+            return True
+    except ApiException as e:
+        logging.error(f"Cluster is not ready: {e}")
+    return False

--- a/operator/webapp/core/k8s_client.py
+++ b/operator/webapp/core/k8s_client.py
@@ -57,7 +57,10 @@ def create_integration_route(route_data: RouteData, configmap_name: str) -> Reso
     body = {
         "apiVersion": "keip.codice.org/v1alpha1",
         "kind": "IntegrationRoute",
-        "metadata": {"name": route_data.route_name},
+        "metadata": {
+            "name": route_data.route_name,
+            "labels": {"app.kubernetes.io/created-by": "keip"}
+        },
         "spec": {"routeConfigMap": configmap_name},
     }
 
@@ -97,7 +100,8 @@ def create_route_configmap(route_data: RouteData) -> Resource:
     configmap_name = f"{route_data.route_name}-cm"
     configmap = client.V1ConfigMap(
         metadata=client.V1ObjectMeta(
-            name=configmap_name, namespace=route_data.namespace
+            name=configmap_name, namespace=route_data.namespace,
+            labels={"app.kubernetes.io/created-by": "keip"}
         ),
         data={"integrationRoute.xml": route_data.route_file},
     )

--- a/operator/webapp/core/sync.py
+++ b/operator/webapp/core/sync.py
@@ -256,7 +256,6 @@ def _spring_app_config_env_var(parent) -> Optional[Mapping]:
 
 
 def _get_keystore_password_env(tls) -> Mapping[str, Any]:
-
     keystore = tls.get("keystore")
 
     if not keystore:
@@ -276,7 +275,6 @@ def _get_keystore_password_env(tls) -> Mapping[str, Any]:
 
 
 def _get_java_jdk_options(tls) -> Optional[Mapping[str, str]]:
-
     truststore = tls.get("truststore")
 
     if not truststore:
@@ -312,7 +310,6 @@ def _generate_container_env_vars(parent) -> List[Mapping[str, str]]:
 
 
 def _create_pod_template(parent, labels, integration_image) -> Mapping[str, Any]:
-
     vol_config = VolumeConfig(parent["spec"])
 
     has_tls = _has_tls(parent)
@@ -429,7 +426,7 @@ def _new_actuator_service(parent):
                 "integration-route": parent_metadata["name"],
                 "prometheus-metrics-enabled": "true",
             },
-            "name": f'{parent_metadata["name"]}-actuator',
+            "name": f"{parent_metadata['name']}-actuator",
         },
         "spec": {
             "ports": [

--- a/operator/webapp/core/test/test_k8s_client.py
+++ b/operator/webapp/core/test/test_k8s_client.py
@@ -1,0 +1,163 @@
+import pytest
+from kubernetes import client
+from core.k8s_client import (
+    create_integration_route,
+    create_route_configmap,
+    is_cluster_ready,
+)
+from models import RouteData, Resource, Status
+from kubernetes.client.rest import ApiException
+
+
+@pytest.fixture
+def route_data():
+    return RouteData(
+        namespace="default",
+        route_name="my-route",
+        route_file="<xml>payload</xml>",
+    )
+
+
+@pytest.fixture(autouse=True)
+def mock_api(mocker):
+    """Patch the global `v1` and `routeApi` objects used by k8s_client."""
+    v1 = mocker.patch("core.k8s_client.v1")
+    route_api = mocker.patch("core.k8s_client.routeApi")
+    return {"v1": v1, "route_api": route_api}
+
+
+def test_create_route_configmap_creates_new(route_data, mock_api):
+    """When no ConfigMap exists the function should call create_namespaced_config_map."""
+    cm_list = client.V1ConfigMapList(items=[])
+    mock_api["v1"].list_namespaced_config_map.return_value = cm_list
+
+    res: Resource = create_route_configmap(route_data)
+
+    # Verify that the correct name is returned
+    assert res.name == f"{route_data.route_name}-cm"
+    assert res.status == Status.CREATED
+
+
+def test_create_route_configmap_updates_existing(mocker, route_data, mock_api):
+    """When a ConfigMap already exists the function should replace it."""
+    cm_name = f"{route_data.route_name}-cm"
+    existing_cm = client.V1ConfigMap(
+        metadata=client.V1ObjectMeta(name=cm_name, namespace="default"),
+        data={"integrationRoute.xml": "<old/>"},
+    )
+    cm_list = client.V1ConfigMapList(items=[existing_cm])
+    mock_api["v1"].list_namespaced_config_map.return_value = cm_list
+
+    res: Resource = create_route_configmap(route_data)
+
+    assert res.name == cm_name
+    assert res.status == Status.UPDATED
+
+
+def test_create_integration_route_creates_new(route_data, mock_api):
+    """When no IntegrationRoute exists the function should call create."""
+    mock_api["route_api"].list_namespaced_custom_object.return_value = {"items": []}
+
+    res: Resource = create_integration_route(route_data, f"{route_data.route_name}-cm")
+
+    assert res.name == route_data.route_name
+    assert res.status == Status.CREATED
+
+
+def test_create_integration_route_updates_existing(route_data, mock_api):
+    """When an IntegrationRoute exists the function should recreate it."""
+    existing_ir = {"metadata": {"name": "old-ir"}}
+    mock_api["route_api"].list_namespaced_custom_object.return_value = {
+        "items": [existing_ir]
+    }
+
+    res: Resource = create_integration_route(route_data, f"{route_data.route_name}-cm")
+
+    assert res.name == route_data.route_name
+    assert res.status == Status.RECREATED
+
+
+@pytest.mark.parametrize("ready_flag", [True, False])
+def test_is_cluster_ready_various(mocker, ready_flag):
+    """Verify that the function returns True only when at least one pod is Ready."""
+    mock_pod = client.V1Pod(
+        metadata=client.V1ObjectMeta(
+            name="integrationroute-webhook-pod", namespace="default"
+        ),
+        status=client.V1PodStatus(
+            phase="Running",
+            conditions=[client.V1PodCondition(type="Ready", status=ready_flag)],
+        ),
+    )
+    pod_list = client.V1PodList(items=[mock_pod])
+
+    mock_v1 = mocker.patch("core.k8s_client.v1")
+    mock_v1.list_pod_for_all_namespaces.return_value = pod_list
+
+    assert is_cluster_ready() == ready_flag
+
+
+def test_is_cluster_ready_no_matching_pods(mocker):
+    """When there are no pods with the prefix, the function should return False."""
+    pod_list = client.V1PodList(items=[])
+    mock_v1 = mocker.patch("core.k8s_client.v1")
+    mock_v1.list_pod_for_all_namespaces.return_value = pod_list
+
+    assert not is_cluster_ready()
+
+
+def test_is_cluster_ready_pod_no_conditions(mocker):
+    """When a pod has no conditions, the function should return False."""
+    mock_pod = client.V1Pod(
+        metadata=client.V1ObjectMeta(
+            name="integrationroute-webhook-pod", namespace="default"
+        ),
+        status=client.V1PodStatus(
+            phase="Running",
+            conditions=[],
+        ),
+    )
+    pod_list = client.V1PodList(items=[mock_pod])
+
+    mock_v1 = mocker.patch("core.k8s_client.v1")
+    mock_v1.list_pod_for_all_namespaces.return_value = pod_list
+
+    assert not is_cluster_ready()
+
+
+def test_is_cluster_ready_api_exception(mocker):
+    """When an ApiException is raised, the function should return False."""
+    mock_v1 = mocker.patch("core.k8s_client.v1")
+    mock_v1.list_pod_for_all_namespaces.side_effect = ApiException()
+
+    assert not is_cluster_ready()
+
+
+def test_create_integration_route_cluster_not_reachable(route_data, mocker):
+    """When the cluster is not reachable, create_integration_route should raise an ApiException."""
+    mocker.patch("core.k8s_client._check_cluster_reachable", return_value=False)
+    with pytest.raises(ApiException):
+        create_integration_route(route_data, "configmap-name")
+
+
+def test_create_route_configmap_cluster_not_reachable(route_data, mocker):
+    """When the cluster is not reachable, create_route_configmap should raise an ApiException."""
+    mocker.patch("core.k8s_client._check_cluster_reachable", return_value=False)
+    with pytest.raises(ApiException):
+        create_route_configmap(route_data)
+
+
+def test_is_cluster_ready_pod_no_status(mocker):
+    """When a pod has no status, the function should return False."""
+    mock_pod = client.V1Pod(
+        metadata=client.V1ObjectMeta(
+            name="integrationroute-webhook-pod", namespace="default"
+        ),
+        status=None,
+    )
+    pod_list = client.V1PodList(items=[mock_pod])
+
+    mock_v1 = mocker.patch("core.k8s_client.v1")
+    mock_v1.list_pod_for_all_namespaces.return_value = pod_list
+
+    assert not is_cluster_ready()

--- a/operator/webapp/core/test/test_k8s_client.py
+++ b/operator/webapp/core/test/test_k8s_client.py
@@ -1,10 +1,6 @@
 import pytest
 from kubernetes import client
-from core.k8s_client import (
-    create_integration_route,
-    create_route_configmap,
-    is_cluster_ready,
-)
+from core.k8s_client import create_integration_route, create_route_configmap
 from models import RouteData, Resource, Status
 from kubernetes.client.rest import ApiException
 
@@ -77,62 +73,6 @@ def test_create_integration_route_updates_existing(route_data, mock_api):
     assert res.status == Status.RECREATED
 
 
-@pytest.mark.parametrize("ready_flag", [True, False])
-def test_is_cluster_ready_various(mocker, ready_flag):
-    """Verify that the function returns True only when at least one pod is Ready."""
-    mock_pod = client.V1Pod(
-        metadata=client.V1ObjectMeta(
-            name="integrationroute-webhook-pod", namespace="default"
-        ),
-        status=client.V1PodStatus(
-            phase="Running",
-            conditions=[client.V1PodCondition(type="Ready", status=ready_flag)],
-        ),
-    )
-    pod_list = client.V1PodList(items=[mock_pod])
-
-    mock_v1 = mocker.patch("core.k8s_client.v1")
-    mock_v1.list_pod_for_all_namespaces.return_value = pod_list
-
-    assert is_cluster_ready() == ready_flag
-
-
-def test_is_cluster_ready_no_matching_pods(mocker):
-    """When there are no pods with the prefix, the function should return False."""
-    pod_list = client.V1PodList(items=[])
-    mock_v1 = mocker.patch("core.k8s_client.v1")
-    mock_v1.list_pod_for_all_namespaces.return_value = pod_list
-
-    assert not is_cluster_ready()
-
-
-def test_is_cluster_ready_pod_no_conditions(mocker):
-    """When a pod has no conditions, the function should return False."""
-    mock_pod = client.V1Pod(
-        metadata=client.V1ObjectMeta(
-            name="integrationroute-webhook-pod", namespace="default"
-        ),
-        status=client.V1PodStatus(
-            phase="Running",
-            conditions=[],
-        ),
-    )
-    pod_list = client.V1PodList(items=[mock_pod])
-
-    mock_v1 = mocker.patch("core.k8s_client.v1")
-    mock_v1.list_pod_for_all_namespaces.return_value = pod_list
-
-    assert not is_cluster_ready()
-
-
-def test_is_cluster_ready_api_exception(mocker):
-    """When an ApiException is raised, the function should return False."""
-    mock_v1 = mocker.patch("core.k8s_client.v1")
-    mock_v1.list_pod_for_all_namespaces.side_effect = ApiException()
-
-    assert not is_cluster_ready()
-
-
 def test_create_integration_route_cluster_not_reachable(route_data, mocker):
     """When the cluster is not reachable, create_integration_route should raise an ApiException."""
     mocker.patch("core.k8s_client._check_cluster_reachable", return_value=False)
@@ -145,19 +85,3 @@ def test_create_route_configmap_cluster_not_reachable(route_data, mocker):
     mocker.patch("core.k8s_client._check_cluster_reachable", return_value=False)
     with pytest.raises(ApiException):
         create_route_configmap(route_data)
-
-
-def test_is_cluster_ready_pod_no_status(mocker):
-    """When a pod has no status, the function should return False."""
-    mock_pod = client.V1Pod(
-        metadata=client.V1ObjectMeta(
-            name="integrationroute-webhook-pod", namespace="default"
-        ),
-        status=None,
-    )
-    pod_list = client.V1PodList(items=[mock_pod])
-
-    mock_v1 = mocker.patch("core.k8s_client.v1")
-    mock_v1.list_pod_for_all_namespaces.return_value = pod_list
-
-    assert not is_cluster_ready()

--- a/operator/webapp/models.py
+++ b/operator/webapp/models.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+
+
+class Status:
+    CREATED = "created"
+    DELETED = "deleted"
+    UPDATED = "updated"
+    RECREATED = "recreated"
+
+
+@dataclass
+class RouteData:
+
+    route_name: str
+    route_file: str
+    namespace: str = "default"
+
+
+@dataclass
+class Resource:
+    name: str
+    status: Status

--- a/operator/webapp/requirements-dev.txt
+++ b/operator/webapp/requirements-dev.txt
@@ -3,4 +3,5 @@ coverage==7.10.6
 httpx==0.28.1
 mypy==1.18.1
 pytest==8.4.2
+pytest-mock==3.14.1
 ruff==0.13.0

--- a/operator/webapp/requirements.txt
+++ b/operator/webapp/requirements.txt
@@ -1,2 +1,4 @@
+kubernetes==33.1.0
+python-multipart
 starlette==0.47.3
 uvicorn[standard]==0.35.0

--- a/operator/webapp/routes/deploy.py
+++ b/operator/webapp/routes/deploy.py
@@ -19,6 +19,24 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def deploy_route(request: Request):
+    """
+    Handles the deployment of an integration route via an XML file upload.
+
+    The endpoint accepts a POST request with an XML file uploaded via form data.
+    It validates the file content type, extracts the route name from the filename,
+    and creates Kubernetes resources for the route using the provided XML configuration.
+
+    Args:
+        request (Request): The incoming HTTP request containing the form data.
+
+    Returns:
+        JSONResponse: A 201 status code response with the created resources in JSON format.
+
+    Raises:
+        HTTPException: If the upload file is missing or has an invalid content type.
+        UnicodeDecodeError: If the XML file cannot be decoded properly.
+        HTTPException: If an unexpected error occurs during processing.
+    """
     _LOGGER.info("Received deployment request")
     try:
         async with request.form() as form:
@@ -62,6 +80,20 @@ async def deploy_route(request: Request):
 
 
 def _generate_route_name(filename: str) -> str:
+    """
+    Generates a valid route name from a filename by replacing underscores with hyphens
+    and removing invalid characters, ensuring it adheres to Kubernetes naming conventions.
+
+    Args:
+        filename (str): The original filename from which to generate the route name.
+
+    Returns:
+        str: A cleaned, valid route name in lowercase with only alphanumeric characters and hyphens.
+
+    Example:
+        Input: "my-route_with_invalid_chars.txt"
+        Output: "my-route-with-invalid-chars"
+    """
     filename = filename.replace("_", "-")
     filename = re.sub(r"[^a-z0-9-]", "", filename.lower())
     filename = filename.strip("-")

--- a/operator/webapp/routes/deploy.py
+++ b/operator/webapp/routes/deploy.py
@@ -78,7 +78,7 @@ def _generate_route_name(filename: str) -> str:
 
 router = Router(
     [
-        Route("/", endpoint=deploy_route, methods=["POST"]),
+        Route("/route", endpoint=deploy_route, methods=["POST"]),
         Route("/cluster-health", endpoint=get_cluster_health, methods=["GET"]),
     ]
 )

--- a/operator/webapp/routes/deploy.py
+++ b/operator/webapp/routes/deploy.py
@@ -100,4 +100,4 @@ def _generate_route_name(filename: str) -> str:
     return filename
 
 
-router = Router([Route("/route", endpoint=deploy_route, methods=["POST"])])
+router = Router([Route("/", endpoint=deploy_route, methods=["POST"])])

--- a/operator/webapp/routes/deploy.py
+++ b/operator/webapp/routes/deploy.py
@@ -61,14 +61,6 @@ async def deploy_route(request: Request):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-async def get_cluster_health(request: Request):
-    _LOGGER.info("Received cluster health request")
-    if k8s_client.is_cluster_ready():
-        return JSONResponse(content={"status": "UP"}, status_code=200)
-    else:
-        return JSONResponse(content={"status": "DOWN"}, status_code=200)
-
-
 def _generate_route_name(filename: str) -> str:
     filename = filename.replace("_", "-")
     filename = re.sub(r"[^a-z0-9-]", "", filename.lower())
@@ -76,9 +68,4 @@ def _generate_route_name(filename: str) -> str:
     return filename
 
 
-router = Router(
-    [
-        Route("/route", endpoint=deploy_route, methods=["POST"]),
-        Route("/cluster-health", endpoint=get_cluster_health, methods=["GET"]),
-    ]
-)
+router = Router([Route("/route", endpoint=deploy_route, methods=["POST"])])

--- a/operator/webapp/routes/test/test_deploy.py
+++ b/operator/webapp/routes/test/test_deploy.py
@@ -14,7 +14,7 @@ def mock_k8s_client(mocker):
 @pytest.fixture(scope="module")
 def test_client():
     app = Starlette()
-    app.mount("/deploy", deploy.router)
+    app.mount("/route", deploy.router)
     return TestClient(app)
 
 
@@ -25,7 +25,7 @@ def test_deploy_route(mock_k8s_client, test_client):
     mock_k8s_client.create_route_resources.return_value = resources
 
     res = test_client.post(
-        "/deploy/route",
+        "/route/",
         files={
             "upload_file": (
                 "my-route.xml",
@@ -45,7 +45,7 @@ def test_deploy_route(mock_k8s_client, test_client):
 @pytest.mark.parametrize("content_type", ["application/json", ""])
 def test_deploy_route_invalid_content_type(test_client, content_type):
     res = test_client.post(
-        "/deploy/route",
+        "/route/",
         files={
             "upload_file": (
                 "my-route.xml",
@@ -60,7 +60,7 @@ def test_deploy_route_invalid_content_type(test_client, content_type):
 
 
 def test_deploy_route_missing_upload_file(test_client):
-    res = test_client.post("/deploy/route", files={})
+    res = test_client.post("/route/", files={})
 
     assert res.status_code == 400
     assert "Missing request parameter: upload_file" in res.text
@@ -68,7 +68,7 @@ def test_deploy_route_missing_upload_file(test_client):
 
 def test_deploy_route_unsupported_file_encoding(test_client):
     response = test_client.post(
-        "/deploy/route",
+        "/route/",
         files={
             "upload_file": (
                 "my-route.xml",
@@ -88,7 +88,7 @@ def test_deploy_route_generic_exception(mock_k8s_client, test_client):
     )
 
     res = test_client.post(
-        "/deploy/route",
+        "/route/",
         files={
             "upload_file": (
                 "my-route.xml",

--- a/operator/webapp/routes/test/test_deploy.py
+++ b/operator/webapp/routes/test/test_deploy.py
@@ -12,7 +12,7 @@ def mock_k8s_client(mocker):
 
 
 @pytest.fixture(scope="module")
-def client():
+def test_client():
     app = Starlette()
     app.mount("/deploy", deploy.router)
     return TestClient(app)
@@ -21,11 +21,11 @@ def client():
 resources = [Resource(name="my-route", status=Status.CREATED)]
 
 
-def test_deploy_route(mock_k8s_client, client):
+def test_deploy_route(mock_k8s_client, test_client):
     mock_k8s_client.create_route_resources.return_value = resources
 
-    res = client.post(
-        "/deploy/",
+    res = test_client.post(
+        "/deploy/route",
         files={
             "upload_file": (
                 "my-route.xml",
@@ -43,9 +43,9 @@ def test_deploy_route(mock_k8s_client, client):
 
 
 @pytest.mark.parametrize("content_type", ["application/json", ""])
-def test_deploy_route_invalid_content_type(client, content_type):
-    res = client.post(
-        "/deploy/",
+def test_deploy_route_invalid_content_type(test_client, content_type):
+    res = test_client.post(
+        "/deploy/route",
         files={
             "upload_file": (
                 "my-route.xml",
@@ -59,16 +59,16 @@ def test_deploy_route_invalid_content_type(client, content_type):
     assert "No Integration Route XML file found in form data" in res.text
 
 
-def test_deploy_route_missing_upload_file(mock_k8s_client, client):
-    res = client.post("/deploy/", files={})
+def test_deploy_route_missing_upload_file(test_client):
+    res = test_client.post("/deploy/route", files={})
 
     assert res.status_code == 400
     assert "Missing request parameter: upload_file" in res.text
 
 
-def test_deploy_route_unsupported_file_encoding(mock_k8s_client, client):
-    res = client.post(
-        "/deploy/",
+def test_deploy_route_unsupported_file_encoding(test_client):
+    response = test_client.post(
+        "/deploy/route",
         files={
             "upload_file": (
                 "my-route.xml",
@@ -78,35 +78,35 @@ def test_deploy_route_unsupported_file_encoding(mock_k8s_client, client):
         },
     )
 
-    assert res.status_code == 400
-    assert "Invalid XML file encoding" in res.text
+    assert response.status_code == 400
+    assert "Invalid XML file encoding" in response.text
 
 
-def test_cluster_health(mock_k8s_client, client):
+def test_cluster_health(mock_k8s_client, test_client):
     mock_k8s_client.is_cluster_ready.return_value = True
 
-    response = client.get("/deploy/cluster-health")
+    response = test_client.get("/deploy/cluster-health")
 
     assert response.status_code == 200
     assert response.json() == {"status": "UP"}
 
 
-def test_cluster_health_cluster_down(mock_k8s_client, client):
+def test_cluster_health_cluster_down(mock_k8s_client, test_client):
     mock_k8s_client.is_cluster_ready.return_value = False
 
-    response = client.get("/deploy/cluster-health")
+    response = test_client.get("/deploy/cluster-health")
 
     assert response.status_code == 200
     assert response.json() == {"status": "DOWN"}
 
 
-def test_deploy_route_generic_exception(mock_k8s_client, client):
+def test_deploy_route_generic_exception(mock_k8s_client, test_client):
     mock_k8s_client.create_route_resources.side_effect = Exception(
         "Something went wrong"
     )
 
-    res = client.post(
-        "/deploy/",
+    res = test_client.post(
+        "/deploy/route",
         files={
             "upload_file": (
                 "my-route.xml",

--- a/operator/webapp/routes/test/test_deploy.py
+++ b/operator/webapp/routes/test/test_deploy.py
@@ -1,0 +1,120 @@
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from routes import deploy
+from models import Resource, Status
+
+
+@pytest.fixture
+def mock_k8s_client(mocker):
+    return mocker.patch("routes.deploy.k8s_client")
+
+
+@pytest.fixture(scope="module")
+def client():
+    app = Starlette()
+    app.mount("/deploy", deploy.router)
+    return TestClient(app)
+
+
+resources = [Resource(name="my-route", status=Status.CREATED)]
+
+
+def test_deploy_route(mock_k8s_client, client):
+    mock_k8s_client.create_route_resources.return_value = resources
+
+    res = client.post(
+        "/deploy/",
+        files={
+            "upload_file": (
+                "my-route.xml",
+                b"<?xml version='1.0'?><route>...</route>",
+                "application/xml",
+            )
+        },
+    )
+
+    assert res.status_code == 201
+    result = res.json()
+    assert len(result) == 1
+    assert result[0]["name"] == "my-route"
+    assert result[0]["status"] == Status.CREATED
+
+
+@pytest.mark.parametrize("content_type", ["application/json", ""])
+def test_deploy_route_invalid_content_type(client, content_type):
+    res = client.post(
+        "/deploy/",
+        files={
+            "upload_file": (
+                "my-route.xml",
+                b"<?xml version='1.0'?><route>...</route>",
+                content_type,
+            )
+        },
+    )
+
+    assert res.status_code == 400
+    assert "No Integration Route XML file found in form data" in res.text
+
+
+def test_deploy_route_missing_upload_file(mock_k8s_client, client):
+    res = client.post("/deploy/", files={})
+
+    assert res.status_code == 400
+    assert "Missing request parameter: upload_file" in res.text
+
+
+def test_deploy_route_unsupported_file_encoding(mock_k8s_client, client):
+    res = client.post(
+        "/deploy/",
+        files={
+            "upload_file": (
+                "my-route.xml",
+                "<?xml version='1.0'?><route>...</route>".encode("utf-16"),
+                "application/xml",
+            )
+        },
+    )
+
+    assert res.status_code == 400
+    assert "Invalid XML file encoding" in res.text
+
+
+def test_cluster_health(mock_k8s_client, client):
+    mock_k8s_client.is_cluster_ready.return_value = True
+
+    response = client.get("/deploy/cluster-health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "UP"}
+
+
+def test_cluster_health_cluster_down(mock_k8s_client, client):
+    mock_k8s_client.is_cluster_ready.return_value = False
+
+    response = client.get("/deploy/cluster-health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "DOWN"}
+
+
+def test_deploy_route_generic_exception(mock_k8s_client, client):
+    mock_k8s_client.create_route_resources.side_effect = Exception(
+        "Something went wrong"
+    )
+
+    res = client.post(
+        "/deploy/",
+        files={
+            "upload_file": (
+                "my-route.xml",
+                b"<?xml version='1.0'?><route>...</route>",
+                "application/xml",
+            )
+        },
+    )
+
+    assert res.status_code == 500
+    assert "Internal server error" in res.text

--- a/operator/webapp/routes/test/test_deploy.py
+++ b/operator/webapp/routes/test/test_deploy.py
@@ -82,24 +82,6 @@ def test_deploy_route_unsupported_file_encoding(test_client):
     assert "Invalid XML file encoding" in response.text
 
 
-def test_cluster_health(mock_k8s_client, test_client):
-    mock_k8s_client.is_cluster_ready.return_value = True
-
-    response = test_client.get("/deploy/cluster-health")
-
-    assert response.status_code == 200
-    assert response.json() == {"status": "UP"}
-
-
-def test_cluster_health_cluster_down(mock_k8s_client, test_client):
-    mock_k8s_client.is_cluster_ready.return_value = False
-
-    response = test_client.get("/deploy/cluster-health")
-
-    assert response.status_code == 200
-    assert response.json() == {"status": "DOWN"}
-
-
 def test_deploy_route_generic_exception(mock_k8s_client, test_client):
     mock_k8s_client.create_route_resources.side_effect = Exception(
         "Something went wrong"

--- a/operator/webapp/routes/webhook.py
+++ b/operator/webapp/routes/webhook.py
@@ -12,7 +12,6 @@ from starlette.status import HTTP_400_BAD_REQUEST
 from core.sync import sync
 from addons.certmanager.main import sync_certificate
 
-
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -40,6 +39,13 @@ def build_webhook(sync_func: Callable[[Mapping], Mapping]):
 
 
 async def status(request):
+    """
+    responses:
+        200:
+            description: The liveness status of the webhook
+            examples:
+                [{"status":"UP"}]
+    """
     return JSONResponse({"status": "UP"})
 
 

--- a/operator/webapp/routes/webhook.py
+++ b/operator/webapp/routes/webhook.py
@@ -12,6 +12,7 @@ from starlette.status import HTTP_400_BAD_REQUEST
 from core.sync import sync
 from addons.certmanager.main import sync_certificate
 
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -39,13 +40,6 @@ def build_webhook(sync_func: Callable[[Mapping], Mapping]):
 
 
 async def status(request):
-    """
-    responses:
-        200:
-            description: The liveness status of the webhook
-            examples:
-                [{"status":"UP"}]
-    """
     return JSONResponse({"status": "UP"})
 
 


### PR DESCRIPTION
## About
Introduces a new deployment endpoint and the core Kubernetes client functionality to manage Integration Routes in Kubernetes. The implementation enables users to upload an XML-based integration route configuration and deploy it as a Kubernetes Custom Resource.
The deployment flow creates two resources:
  - A ConfigMap containing the XML route payload.
  - An IntegrationRoute Custom Resource (CR) that references the ConfigMap.